### PR TITLE
A headless browser test for MathJax Errors.

### DIFF
--- a/gerby/tests/README.md
+++ b/gerby/tests/README.md
@@ -1,0 +1,19 @@
+Tests
+=====
+
+The script `find_tex_errors.py` runs a headless browser through all tags
+corresponding to sections and looks for MathJax errors. When TeX errors are
+found, they are reported in console by a print statement. The tag at which this
+error is found is given, together with the offending LaTeX code.
+
+To run this script:
+
+  1. Install `selenium`, via `pip install selenium`. See the
+  [docs](http://selenium-python.readthedocs.io/) for more detail.
+  2. Install `geckodriver` to run the Firefox webdriver. Obtain the binary
+  [here](https://github.com/mozilla/geckodriver/releases), and put it somewhere
+  where your `PATH` variable can find.
+  3. Change the parameters `database` and `url` in `find_tex_errors.py` as
+  needed.
+  4. Run `python find_tex_errors.py`.
+

--- a/gerby/tests/README.md
+++ b/gerby/tests/README.md
@@ -15,5 +15,6 @@ To run this script:
   where your `PATH` variable can find.
   3. Change the parameters `database` and `url` in `find_tex_errors.py` as
   needed.
-  4. Run `python find_tex_errors.py`.
+  4. Run your Flask app.
+  5. Run `python find_tex_errors.py`.
 

--- a/gerby/tests/find_tex_errors.py
+++ b/gerby/tests/find_tex_errors.py
@@ -1,0 +1,45 @@
+from sqlite3 import connect
+from selenium import webdriver
+
+database = "../stacks.sqlite"
+url = "http://localhost:5000"
+find_tex_errors = """
+allJax = MathJax.Hub.getAllJax();
+errors = [];
+for (i = 0; i < allJax.length; i++) {
+    if(allJax[i].texError) {
+        errors.push(allJax[i].originalText);
+    }
+}
+return errors;
+"""
+
+def get_tex_errors_on_tag(tag,browser=None):
+    if browser is None:
+        browser = webdriver.Firefox()
+    browser.get("{0}/tag/{1}".format(url,tag))
+    errors = browser.execute_script(find_tex_errors)
+    if browser is None:
+        browser.quit()
+    return errors
+
+conn = connect(database)
+c = conn.cursor()
+c.execute('SELECT tag FROM tag WHERE type IS "section";')
+tags = c.fetchall()
+conn.close()
+print("There are {0} sections.".format(len(tags)))
+
+browser = webdriver.Firefox()
+sections_done = 0
+for tag in tags:
+    errors = get_tex_errors_on_tag(tag[0],browser=browser)
+    if errors:
+        print("There are TeX errors at Tag {0}:".format(tag[0]))
+        for error in errors:
+            print(error)
+    sections_done += 1
+    if sections_done % 100 == 0:
+        print("--- Done testing {0} sections.".format(sections_done))
+
+browser.quit()


### PR DESCRIPTION
This is a quick and dirty script to find MathJax errors in, say, the Stacks Project. I have run the script and it appears that there are only two remaining MathJax problems:

  1. There is a problem with using ``{\rm ...}`` in ``xymatrix``: see Tag 0DP6, even on the actual Stacks Project page;
  2. MathJax does not know what ``linebreak`` is: see Tag 03XB.

Both of these remaining problems are not problems in plasTeX.
