### PR TITLE
Add macro definition for linebreak.

### DIFF
--- a/gerby/templates/layout.html
+++ b/gerby/templates/layout.html
@@ -11,7 +11,13 @@
     MathJax.Hub.Config({
       extensions: ['tex2jax.js'],
       jax: ['input/TeX','output/HTML-CSS'],
-      TeX: {extensions: ['AMSmath.js', 'AMSsymbols.js', '/static/XyJax/extensions/TeX/xypic.js'], TagSide: 'left'},
+      TeX: {
+        extensions: ['AMSmath.js', 'AMSsymbols.js', '/static/XyJax/extensions/TeX/xypic.js'],
+        Macros: {
+          linebreak: ["", 1, ""],
+          }
+        TagSide: 'left'
+      },
       tex2jax: {
         inlineMath: [['$','$']],
         displayMath: [ ['$$','$$'], ["\\[","\\]"] ],


### PR DESCRIPTION
Small change to fix item 5 in issue [#21](https://github.com/pbelmans/plastex/issues/21) in the plasTeX repository.