### PR TITLE
Extend breadcrumb links over the full tag title

### DIFF
--- a/gerby/templates/macros.html
+++ b/gerby/templates/macros.html
@@ -64,7 +64,7 @@
 
 {% macro breadcrumb(breadcrumb) %}
   {% for parent in breadcrumb %}
-    <li{% if loop.last %} class="active"{% endif %}>{{ parent.type | capitalize }} <a href="/tag/{{ parent.tag }}" data-tag="{{ parent.tag }}">{{ parent.ref }}</a>{% if parent.name %}: {{ parent.name }}{% endif %}
+    <li{% if loop.last %} class="active"{% endif %}><a href="/tag/{{ parent.tag }}" data-tag="{{ parent.tag }}">{{ parent.type | capitalize }} {{ parent.ref }}{% if parent.name %}: {{ parent.name }}{% endif %}</a>
     {% if loop.last %}<span id="citation">(<a href="/tag/{{ parent.tag }}/cite">cite</a>)</span>{% endif %}
   {% endfor %}
 {% endmacro %}


### PR DESCRIPTION
Currently, the links in the breadcrumbs extend only over the part/chapter/section number, not on the full tag title. I find it difficult to click on these short links, especially on mobile. This pull request changes the design so that the links extend over the full title. Beware that I haven't tested this change!

On an unrelated note, I noticed that the code doesn't include closing `</li>` tags. Should we add them for good measure?