### PR TITLE
Fixed issue (Safari) where one cannot press the left arrow key

### DIFF
--- a/gerby/templates/search.html
+++ b/gerby/templates/search.html
@@ -91,8 +91,11 @@
 
   <script type="text/javascript">
 // synchronise the two text inputs
-$("input[type=search]").on("paste keyup", function() {
-  $("input[type=search]").val($(this).val());
+$("form[id=search] div input[type=search]").on("paste keyup", function() {
+  $("form[id=quicksearch] input[type=search]").val($(this).val());
+});
+$("form[id=quicksearch] input[type=search]").on("paste keyup", function() {
+  $("form[id=search] div input[type=search]").val($(this).val());
 });
   </script>
 


### PR DESCRIPTION
On the Stacks Project website, I had an issue (Safari, but not Chrome) on the search page where when I tried to press "left" to go back and edit my query, I would not be able to. This fix worked on my computer, but I don't know how to test it with Gerby itself.